### PR TITLE
Fix FR 9-12 unlocks too early

### DIFF
--- a/world-restoration-bullzmade/game/javascripts/fork-repellents.js
+++ b/world-restoration-bullzmade/game/javascripts/fork-repellents.js
@@ -49,7 +49,7 @@ function getTotalFRs() {
 
 function unlockForkRepellents() {
     let getFRsUnlocked = function() {
-        if (player.karma.gt(0) || player.gainedKarma.gt(0) || player.prestigeStat[1].gt(0)) {
+        if (player.karma.gt(0) || player.gainedKarma.gt(0) || player.prestigeStat[2].gt(0)) {
             return 12
         } else if (player.cakes.gt(0) || player.gainedCakes.gt(0) || player.prestigeStat[1].gt(0)) {
             return 8


### PR DESCRIPTION
In the original game, FR 9-12 will unlock when you do a layer 3 reset for the first time
but this game unlock when you do layer 2 resets for the first time